### PR TITLE
fix(ops): scan crashes next command

### DIFF
--- a/ops/scan.js
+++ b/ops/scan.js
@@ -24,6 +24,6 @@ export default async function scan(sql, cursor = "0", match, count = 10) {
 
   const res = `*2\r\n$${newCursorString.length}\r\n${newCursorString}\r\n*${
     subset.length
-  }\r\n${response.join("")}\r\n`;
+  }\r\n${response.join("")}`;
   return res;
 }


### PR DESCRIPTION
## to reproduce
```
set foo bar
get foo
scan 0
get foo
```

## expected
last `get foo` returns `"bar"`

## actual
```
Error: Protocol error, got "\r" as reply type byte
```